### PR TITLE
Handle `willReturn` if no `shouldReturn` is found

### DIFF
--- a/rules-tests/Rector/ClassMethod/ConsecutiveMockExpectationRector/Fixture/twice_called_will_return.php.inc
+++ b/rules-tests/Rector/ClassMethod/ConsecutiveMockExpectationRector/Fixture/twice_called_will_return.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\PhpSpecToPHPUnit;
+
+use PhpSpec\ObjectBehavior;
+use Rector\PhpSpecToPHPUnit\Tests\Rector\ClassMethod\ConsecutiveMockExpectationRector\Source\MockedType;
+
+class TwiceCalled extends ObjectBehavior
+{
+    public function it_should(MockedType $mockedType)
+    {
+        $mockedType->set('first_key')->willReturn(100);
+        $mockedType->set('second_key')->willReturn(200);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace spec\PhpSpecToPHPUnit;
+
+use PhpSpec\ObjectBehavior;
+use Rector\PhpSpecToPHPUnit\Tests\Rector\ClassMethod\ConsecutiveMockExpectationRector\Source\MockedType;
+
+class TwiceCalled extends ObjectBehavior
+{
+    public function it_should(MockedType $mockedType)
+    {
+        $mockedType->expects($this->exactly(2))->method('set')->willReturnMap([['first_key', 100], ['second_key', 200]]);
+    }
+}
+
+?>

--- a/src/NodeFactory/WillReturnMapMethodCallFactory.php
+++ b/src/NodeFactory/WillReturnMapMethodCallFactory.php
@@ -93,6 +93,13 @@ final class WillReturnMapMethodCallFactory
                 PhpSpecMethodName::SHOULD_RETURN
             );
 
+            if (empty($returnArgs)) {
+                $returnArgs = $this->resolveInputArgs(
+                    $consecutiveMethodCall->getMethodCall(),
+                    PhpSpecMethodName::WILL_RETURN
+                );
+            }
+
             $arrayItems = $this->createArrayItemsFromArgs([...$inputArgs, ...$returnArgs]);
             $singleCallArray = new Array_($arrayItems);
 


### PR DESCRIPTION
Fix #47 