### PR TITLE
Add `shouldImplement` and related missing tests

### DIFF
--- a/rules-tests/Rector/Class_/PromisesToAssertsRector/Fixture/should_be_instance_of.php.inc
+++ b/rules-tests/Rector/Class_/PromisesToAssertsRector/Fixture/should_be_instance_of.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\Rector\PhpSpecToPHPUnit;
+
+use PhpSpec\ObjectBehavior;
+
+class TestClassMethod extends ObjectBehavior
+{
+    public function let_1()
+    {
+        $this->shouldBeAnInstanceOf(\stdClass::class);
+    }
+
+    public function let_2()
+    {
+        $this->shouldHaveType(\stdClass::class);
+    }
+
+    public function let_3()
+    {
+        $this->shouldReturnAnInstanceOf(\stdClass::class);
+    }
+
+    public function let_4()
+    {
+        $this->shouldImplement(\stdClass::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace spec\Rector\PhpSpecToPHPUnit;
+
+use PhpSpec\ObjectBehavior;
+
+class TestClassMethod extends ObjectBehavior
+{
+    public function let_1()
+    {
+        $this->assertInstanceOf(\stdClass::class, $this->testClassMethod);
+    }
+
+    public function let_2()
+    {
+        $this->assertInstanceOf(\stdClass::class, $this->testClassMethod);
+    }
+
+    public function let_3()
+    {
+        $this->assertInstanceOf(\stdClass::class, $this->testClassMethod);
+    }
+
+    public function let_4()
+    {
+        $this->assertInstanceOf(\stdClass::class, $this->testClassMethod);
+    }
+}
+
+?>

--- a/src/Enum/ProphecyPromisesToPHPUnitAssertMap.php
+++ b/src/Enum/ProphecyPromisesToPHPUnitAssertMap.php
@@ -13,7 +13,7 @@ final class ProphecyPromisesToPHPUnitAssertMap
      * @var array<string, string[]>
      */
     public const PROMISES_BY_ASSERT_METHOD = [
-        'assertInstanceOf' => ['shouldBeAnInstanceOf', 'shouldHaveType', 'shouldReturnAnInstanceOf'],
+        'assertInstanceOf' => ['shouldBeAnInstanceOf', 'shouldHaveType', 'shouldReturnAnInstanceOf', 'shouldImplement'],
         'assertSame' => ['shouldBe', 'shouldReturn'],
         'assertNotSame' => ['shouldNotBe', 'shouldNotReturn'],
         'assertCount' => ['shouldHaveCount'],


### PR DESCRIPTION
This pull request includes changes to the `rules-tests/Rector/Class_/PromisesToAssertsRector/Fixture/should_be_instance_of.php.inc` and `src/Enum/ProphecyPromisesToPHPUnitAssertMap.php` files to enhance the conversion of PhpSpec promises to PHPUnit assertions. The most important changes include adding new test cases and updating the mapping of promises to assertions.

Enhancements to test cases:

* [`rules-tests/Rector/Class_/PromisesToAssertsRector/Fixture/should_be_instance_of.php.inc`](diffhunk://#diff-6069569b4095c7a476be30c15daba05afd615dc67861aed3bc47b630a523a7b0R1-R61): Added new test cases to convert various PhpSpec promises (`shouldBeAnInstanceOf`, `shouldHaveType`, `shouldReturnAnInstanceOf`, `shouldImplement`) to their corresponding PHPUnit assertions (`assertInstanceOf`).

Updates to promise-to-assertion mapping:

* [`src/Enum/ProphecyPromisesToPHPUnitAssertMap.php`](diffhunk://#diff-8a492a1e5cc33adf66b2045b20a7eb5c2ef57c5f1a8ed9250fda8b33b1d57df0L16-R16): Updated the `PROMISES_BY_ASSERT_METHOD` array to include the `shouldImplement` promise under the `assertInstanceOf` assertion.